### PR TITLE
 Add mdbook 0.5.x Support

### DIFF
--- a/.github/workflows/setup/action.yaml
+++ b/.github/workflows/setup/action.yaml
@@ -21,7 +21,7 @@ runs:
     - name: Install mdbook
       run: |
         mkdir bin
-        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.45/mdbook-v0.4.45-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+        curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
         echo "$(pwd)/bin" >> ${GITHUB_PATH}
       shell: bash
     - name: Initialize TS bindings

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 target/
 bindings/
 .pnpm-debug.log
+
+# Generated JS/CSS assets (built by depot)
+crates/mdbook-quiz/js/*.js
+crates/mdbook-quiz/js/*.css
+crates/mdbook-quiz/js/*.wasm
+crates/mdbook-quiz/js/*.map

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "toml 0.5.11",
  "toml_edit",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
 ]
@@ -164,7 +164,7 @@ checksum = "2b6c8cdacd3b63a72547f2dcbd3236e7af6ae3e331555876fb70b1da067eaf3b"
 dependencies = [
  "anyhow",
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "headers"
@@ -1169,12 +1169,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1440,7 +1440,7 @@ dependencies = [
  "shlex",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "topological-sort",
  "walkdir",
  "warp",
@@ -1472,6 +1472,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdbook-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a3873d4afac65583f1acb56ff058df989d5b4a2464bb02c785549727d307ee"
+dependencies = [
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
+ "toml 0.9.10+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "mdbook-preprocessor"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d87bf40be0597f26f0822f939a64f02bf92c4655ba04490aadbf83601a013bb"
+dependencies = [
+ "anyhow",
+ "mdbook-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mdbook-preprocessor-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,25 +1514,29 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "tempfile",
 ]
 
 [[package]]
 name = "mdbook-quiz"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
+ "env_logger 0.10.2",
  "html-escape",
  "log",
- "mdbook",
  "mdbook-aquascope",
- "mdbook-preprocessor-utils",
+ "mdbook-core",
+ "mdbook-preprocessor",
  "mdbook-quiz-schema",
  "mdbook-quiz-validate",
+ "rayon",
  "regex",
+ "semver",
+ "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "toml_edit",
  "uuid",
 ]
@@ -1518,7 +1548,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "ts-rs 7.1.1",
 ]
 
@@ -1534,7 +1564,7 @@ dependencies = [
  "tempfile",
  "textwrap 0.16.2",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.5.11",
  "toml-spanned-value",
  "zspell",
 ]
@@ -2068,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2080,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2193,18 +2223,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2224,14 +2264,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2621,13 +2671,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml-spanned-value"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a1991312b7a0e66feb44bc16d97861c20ca476a3c6960bf888d25030dcf4d9f"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2637,15 +2702,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.9",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "topological-sort"
@@ -2661,20 +2750,32 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.33"
+name = "tracing-attributes"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3332,6 +3433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,6 +3550,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cc0158b0d3103d58e9e82bdbe9cf9289d80dbcf4e686ff16730eb9e5814d1a"
 
 [[package]]
 name = "zspell"

--- a/crates/mdbook-quiz/Cargo.toml
+++ b/crates/mdbook-quiz/Cargo.toml
@@ -3,7 +3,7 @@ name = "mdbook-quiz"
 authors = ["Will Crichton <crichton.will@gmail.com>"]
 description = "Interactive quizzes for your mdBook"
 license = "MIT OR Apache-2.0"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 include = ["/src", "/js"]
 repository = "https://github.com/cognitive-engineering-lab/mdbook-quiz"
@@ -16,23 +16,26 @@ source-map = []
 
 [dependencies]
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 anyhow = { workspace = true, features = ["backtrace"] }
 regex = "1"
 html-escape = "0.2"
 toml = { workspace = true }
-mdbook = "= 0.4.45"
-mdbook-preprocessor-utils = "0.2.0"
+mdbook-preprocessor = "0.5"
+mdbook-core = "0.5"
+rayon = "1"
+env_logger = "0.10.0"
+log = "0.4.20"
+chrono = "0.4.31"
+semver = "1"
 mdbook-aquascope = { version = "=0.3.6", optional = true }
 mdbook-quiz-schema = { path = "../mdbook-quiz-schema", version = "0.4.0" }
 mdbook-quiz-validate = { path = "../mdbook-quiz-validate", version = "0.4.0" }
 toml_edit = "0.20.0"
 uuid = {version = "1.4.1", features = ["v4"]}
-log = "0.4.20"
 clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
-mdbook-preprocessor-utils = { version = "0.2.0", features = ["testing"] }
 
 [build-dependencies]
 anyhow = { workspace = true }
-mdbook-preprocessor-utils = "0.2.0"

--- a/crates/mdbook-quiz/Cargo.toml
+++ b/crates/mdbook-quiz/Cargo.toml
@@ -36,6 +36,7 @@ uuid = {version = "1.4.1", features = ["v4"]}
 clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/mdbook-quiz/build.rs
+++ b/crates/mdbook-quiz/build.rs
@@ -1,30 +1,71 @@
-use anyhow::Result;
-use std::{path::Path, process::Command};
+use anyhow::{Error, Result};
+use std::{fs, io::ErrorKind, path::Path, process::Command};
 
 const BINDINGS_DIR: &str = "../../js/packages/quiz/src/bindings";
 const JS_DIST_DIR: &str = "../../js/packages/quiz-embed/dist";
 const LOCAL_JS_DIST_DIR: &str = "./js";
 
+fn copy_assets(src_dir: impl AsRef<Path>, dst_dir: impl AsRef<Path>) -> Result<()> {
+  let src_dir = src_dir.as_ref();
+  let dst_dir = dst_dir.as_ref();
+
+  println!("cargo:rerun-if-changed={}", src_dir.display());
+  fs::create_dir_all(dst_dir)?;
+
+  let src_entries = match fs::read_dir(src_dir) {
+    Ok(src_entries) => src_entries,
+    Err(err) => match err.kind() {
+      ErrorKind::NotFound => return Ok(()),
+      _ => return Err(Error::new(err)),
+    },
+  };
+
+  for entry in src_entries {
+    let path = entry?.path();
+    fs::copy(&path, dst_dir.join(path.file_name().unwrap()))?;
+  }
+
+  Ok(())
+}
+
 fn main() -> Result<()> {
   let bindings_dir = Path::new(BINDINGS_DIR);
   if !bindings_dir.exists() {
-    panic!("Must run `cargo make init-bindings`");
+    eprintln!(
+      "Warning: TypeScript bindings not found. Run `just init-bindings` or `cargo test -p mdbook-quiz-schema --features ts export_bindings`"
+    );
+    eprintln!("Continuing anyway - JS assets may not be up to date");
   }
 
   let js_dist_dir = Path::new(JS_DIST_DIR);
   if !js_dist_dir.exists() {
+    eprintln!(
+      "Warning: JS distribution files not found at {}",
+      JS_DIST_DIR
+    );
+    eprintln!("Attempting to build JS with depot...");
+
     let mut cmd = Command::new("depot");
     cmd.current_dir("../../js").arg("build").arg("--release");
     if cfg!(feature = "rust-editor") {
       cmd.env("RUST_EDITOR", "yes");
     }
-    let status = cmd.status()?;
-    if !status.success() || !js_dist_dir.exists() {
-      panic!("Failed to install/build JS")
+
+    match cmd.status() {
+      Ok(status) if status.success() && js_dist_dir.exists() => {
+        println!("Successfully built JS assets");
+      }
+      _ => {
+        eprintln!("Warning: Failed to build JS assets with depot");
+        eprintln!("This is expected if you don't have depot installed");
+        eprintln!("The preprocessor will still compile but JS assets won't be embedded");
+        // Create empty dist directory to avoid errors
+        fs::create_dir_all(js_dist_dir)?;
+      }
     }
   }
 
-  mdbook_preprocessor_utils::copy_assets(JS_DIST_DIR, LOCAL_JS_DIST_DIR)?;
+  copy_assets(JS_DIST_DIR, LOCAL_JS_DIST_DIR)?;
 
   Ok(())
 }

--- a/crates/mdbook-quiz/src/utils/asset.rs
+++ b/crates/mdbook-quiz/src/utils/asset.rs
@@ -1,0 +1,25 @@
+/// Represents a static asset bundled with the preprocessor
+#[derive(Copy, Clone)]
+pub struct Asset {
+  pub name: &'static str,
+  pub contents: &'static [u8],
+}
+
+/// Macro to generate an asset generator macro
+/// Usage: asset_generator!("../js/") creates a make_asset! macro
+#[macro_export]
+macro_rules! asset_generator {
+  ($base:expr) => {
+    macro_rules! make_asset {
+      ($name:expr) => {
+        $crate::utils::Asset {
+          name: $name,
+          contents: include_bytes!(concat!($base, $name)),
+        }
+      };
+    }
+  };
+}
+
+// Re-export for use in other modules
+pub use asset_generator;

--- a/crates/mdbook-quiz/src/utils/html.rs
+++ b/crates/mdbook-quiz/src/utils/html.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use serde::Serialize;
+use std::fmt::Write;
+
+/// Builder for creating HTML div elements with attributes and data attributes
+#[derive(Default)]
+pub struct HtmlElementBuilder {
+  html: String,
+}
+
+impl HtmlElementBuilder {
+  pub fn new() -> Self {
+    let html = String::from("<div");
+    HtmlElementBuilder { html }
+  }
+
+  /// Add an HTML attribute
+  pub fn attr(&mut self, key: &str, value: &str) -> &mut Self {
+    let value_escaped = html_escape::encode_double_quoted_attribute(value);
+    write!(&mut self.html, r#" {key}="{value_escaped}""#).unwrap();
+    self
+  }
+
+  /// Add a data attribute with a JSON-serializable value
+  pub fn data(&mut self, key: &str, value: impl Serialize) -> Result<&mut Self> {
+    let value_json = serde_json::to_string(&value)?;
+    let value_escaped = html_escape::encode_double_quoted_attribute(&value_json);
+    write!(&mut self.html, r#" data-{key}="{value_escaped}""#).unwrap();
+    Ok(self)
+  }
+
+  /// Finish building and return the HTML string
+  pub fn finish(mut self) -> String {
+    write!(&mut self.html, "></div>").unwrap();
+    self.html
+  }
+}

--- a/crates/mdbook-quiz/src/utils/mod.rs
+++ b/crates/mdbook-quiz/src/utils/mod.rs
@@ -1,0 +1,7 @@
+pub mod asset;
+pub mod html;
+pub mod preprocessor;
+
+pub use asset::{Asset, asset_generator};
+pub use html::HtmlElementBuilder;
+pub use preprocessor::SimplePreprocessor;

--- a/crates/mdbook-quiz/src/utils/preprocessor.rs
+++ b/crates/mdbook-quiz/src/utils/preprocessor.rs
@@ -1,0 +1,231 @@
+use std::{
+  env, fs,
+  io::{self, Write as IoWrite},
+  marker::PhantomData,
+  ops::Range,
+  path::{Path, PathBuf},
+  process,
+};
+
+use anyhow::Result;
+use chrono::Local;
+use clap::{Command, CommandFactory, arg};
+use env_logger::Builder;
+use log::LevelFilter;
+use mdbook_preprocessor::{MDBOOK_VERSION, Preprocessor, PreprocessorContext, book::Book};
+use rayon::prelude::*;
+use semver::{Version, VersionReq};
+
+use super::Asset;
+
+/// Simplified trait for implementing mdBook preprocessors
+pub trait SimplePreprocessor: Sized + Send + Sync {
+  type Args: CommandFactory;
+
+  /// The name of the preprocessor
+  fn name() -> &'static str;
+
+  /// Build the preprocessor from the context
+  fn build(ctx: &PreprocessorContext) -> Result<Self>;
+
+  /// Find and generate replacements for the content
+  fn replacements(&self, chapter_dir: &Path, content: &str) -> Result<Vec<(Range<usize>, String)>>;
+
+  /// Assets to link in the HTML output
+  fn linked_assets(&self) -> Vec<Asset>;
+
+  /// All assets to copy to the book directory
+  fn all_assets(&self) -> Vec<Asset>;
+
+  /// Called after processing is complete
+  fn finish(self) {}
+}
+
+struct SimplePreprocessorDriverCtxt<P: SimplePreprocessor> {
+  sp: P,
+  src_dir: PathBuf,
+}
+
+impl<P: SimplePreprocessor> SimplePreprocessorDriverCtxt<P> {
+  fn copy_assets(&self) -> Result<()> {
+    // Rather than copying directly to the build directory, we instead copy to the book source
+    // since mdBook will clean the build-dir after preprocessing. See mdBook#1087 for more.
+    let dst_dir = self.src_dir.join(P::name());
+    fs::create_dir_all(&dst_dir)?;
+
+    for asset in self.sp.all_assets() {
+      fs::write(dst_dir.join(asset.name), asset.contents)?;
+    }
+
+    Ok(())
+  }
+
+  fn process_chapter(&self, chapter_dir: &Path, content: &mut String) -> Result<()> {
+    let mut replacements = self.sp.replacements(chapter_dir, content)?;
+    if !replacements.is_empty() {
+      replacements.sort_by_key(|(range, _)| range.start);
+
+      for (range, html) in replacements.into_iter().rev() {
+        content.replace_range(range, &html);
+      }
+
+      // If a chapter is located at foo/bar/the_chapter.md, then the generated source files
+      // will be at foo/bar/the_chapter.html. So they need to reference preprocessor files
+      // at ../../<preprocessor>/embed.js, i.e. we generate the right number of "..".
+      let chapter_rel_path = chapter_dir.strip_prefix(&self.src_dir).unwrap();
+      let depth = chapter_rel_path.components().count();
+      let prefix = vec![".."; depth].into_iter().collect::<PathBuf>();
+
+      // Ensure there's space between existing markdown and inserted HTML
+      content.push_str("\n\n");
+
+      for asset in self.sp.linked_assets() {
+        let asset_rel = prefix.join(P::name()).join(asset.name);
+        let asset_str = asset_rel.display().to_string();
+        let link = match &*asset_rel.extension().unwrap().to_string_lossy() {
+          "js" => format!(r#"<script type="text/javascript" src="{asset_str}"></script>"#),
+          "mjs" => format!(r#"<script type="module" src="{asset_str}"></script>"#),
+          "css" => format!(r#"<link rel="stylesheet" type="text/css" href="{asset_str}">"#),
+          _ => continue,
+        };
+        content.push_str(&link);
+      }
+    }
+    Ok(())
+  }
+}
+
+pub(crate) struct SimplePreprocessorDriver<P: SimplePreprocessor>(PhantomData<P>);
+
+impl<P: SimplePreprocessor> SimplePreprocessorDriver<P> {
+  pub fn new() -> Self {
+    SimplePreprocessorDriver(PhantomData)
+  }
+}
+
+impl<P: SimplePreprocessor> Preprocessor for SimplePreprocessorDriver<P> {
+  fn name(&self) -> &str {
+    P::name()
+  }
+
+  fn run(&self, ctx: &PreprocessorContext, mut book: Book) -> Result<Book> {
+    let src_dir = ctx.root.join(&ctx.config.book.src);
+    let sp = P::build(ctx)?;
+    let ctxt = SimplePreprocessorDriverCtxt { sp, src_dir };
+    ctxt.copy_assets()?;
+
+    fn for_each_mut<'a, P: SimplePreprocessor>(
+      ctxt: &SimplePreprocessorDriverCtxt<P>,
+      chapters: &mut Vec<(PathBuf, &'a mut String)>,
+      items: impl IntoIterator<Item = &'a mut mdbook_preprocessor::book::BookItem>,
+    ) {
+      for item in items {
+        if let mdbook_preprocessor::book::BookItem::Chapter(chapter) = item
+          && chapter.path.is_some()
+        {
+          let chapter_path_abs = ctxt.src_dir.join(chapter.path.as_ref().unwrap());
+          let chapter_dir = chapter_path_abs.parent().unwrap().to_path_buf();
+          chapters.push((chapter_dir, &mut chapter.content));
+
+          for_each_mut(ctxt, chapters, &mut chapter.sub_items);
+        }
+      }
+    }
+
+    let mut chapters = Vec::new();
+    for_each_mut(&ctxt, &mut chapters, &mut book.items);
+
+    chapters
+      .into_par_iter()
+      .map(|(chapter_dir, content)| ctxt.process_chapter(&chapter_dir, content))
+      .collect::<Result<Vec<_>>>()?;
+
+    ctxt.sp.finish();
+
+    Ok(book)
+  }
+
+  fn supports_renderer(&self, _renderer: &str) -> Result<bool> {
+    Ok(true)
+  }
+}
+
+// This is copied verbatim from mdbook so the style is consistent.
+fn init_logger() {
+  let mut builder = Builder::new();
+
+  builder.format(|formatter, record| {
+    writeln!(
+      formatter,
+      "{} [{}] ({}): {}",
+      Local::now().format("%Y-%m-%d %H:%M:%S"),
+      record.level(),
+      record.target(),
+      record.args()
+    )
+  });
+
+  if let Ok(var) = env::var("RUST_LOG") {
+    builder.parse_filters(&var);
+  } else {
+    // if no RUST_LOG provided, default to logging at the Info level
+    builder.filter(None, LevelFilter::Info);
+    // Filter extraneous html5ever not-implemented messages
+    builder.filter(Some("html5ever"), LevelFilter::Error);
+  }
+
+  builder.init();
+}
+
+fn handle_preprocessing(pre: &dyn Preprocessor) -> Result<()> {
+  let (ctx, book) = mdbook_preprocessor::parse_input(io::stdin())?;
+
+  let book_version = Version::parse(&ctx.mdbook_version)?;
+  let version_req = VersionReq::parse(MDBOOK_VERSION)?;
+
+  if !version_req.matches(&book_version) {
+    eprintln!(
+      "Warning: The {} plugin was built against version {} of mdbook, \
+             but we're being called from version {}",
+      pre.name(),
+      MDBOOK_VERSION,
+      ctx.mdbook_version
+    );
+  }
+
+  let processed_book = pre.run(&ctx, book)?;
+  serde_json::to_writer(io::stdout(), &processed_book)?;
+
+  Ok(())
+}
+
+fn handle_supports(pre: &dyn Preprocessor, renderer: &str) {
+  match pre.supports_renderer(renderer) {
+    Ok(true) => process::exit(0),
+    Ok(false) | Err(_) => process::exit(1),
+  }
+}
+
+/// Main entry point for a SimplePreprocessor
+pub fn main<P: SimplePreprocessor>() {
+  init_logger();
+
+  let args = P::Args::command()
+    .subcommand(Command::new("supports").arg(arg!(<renderer> "Checks if renderer is supported")))
+    .get_matches();
+
+  let preprocessor = SimplePreprocessorDriver::<P>::new();
+
+  match args.subcommand() {
+    Some(("supports", m)) => {
+      let renderer = m.get_one::<String>("renderer").unwrap();
+      handle_supports(&preprocessor, renderer);
+    }
+    _ => {
+      if let Err(e) = handle_preprocessing(&preprocessor) {
+        eprintln!("{}", e);
+        process::exit(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This should Closes #61 

## Summary
This PR adds support for mdbook 0.5.x to mdbook-quiz, migrating away from mdbook 0.4.x. The migration includes extracting internal utilities to replace the deprecated `mdbook-preprocessor-utils`, updating to the new mdbook crate structure, and ensuring all tests pass with the new APIs.

## Changes
This PR consists of 4 commits:

 1. `feat: migrate to mdbook 0.5.x` (3de0657):

**Core Migration:**
- Replace `mdbook 0.4.45` dependency with `mdbook-preprocessor 0.5` and `mdbook-core 0.5`
- Remove dependency on deprecated `mdbook-preprocessor-utils 0.2.0`
**Extract Internal Utilities:**
Since `mdbook-preprocessor-utils` is not available for mdbook 0.5.x, this commit extracts the required utilities into the crate:

**API Migrations:**
- Use `mdbook_preprocessor` instead of `mdbook::preprocess`
- Replace `config.get_preprocessor()` with `config.get()`
- Handle `Result<bool>` return type in `supports_renderer()`
- Update `Book::sections` to `Book::items` iterator

**Build Script Updates:**
- Inline `copy_assets()` implementation
- Make JS build optional with better error handling
- Add depot build attempt with graceful fallback

**Version Bump:** 0.4.0 → 0.5.0

**Breaking Change:** Drops support for mdbook 0.4.x

 3. `ci: update mdbook to v0.5.2` (5ce4017):
- Update CI workflow to use mdbook v0.5.2 instead of v0.4.45, ensuring tests run against the correct mdbook version.

 4. `chore: ignore generated JS/CSS assets` (16d5c5a):
- Add generated JavaScript and CSS assets to `.gitignore`
- `crates/mdbook-quiz/js/*.{js,css,wasm,map}` (These files are generated by the depot build process and should not be committed to the repository.)

 5. `test: implement test harness for mdbook 0.5.x` (5afb0c6):

**Test Migration:**
Since `MdbookTestHarness` from `mdbook-preprocessor-utils` is no longer available, this commit implements a local `TestHarness` for testing the preprocessor with mdbook 0.5.x.

**Testing:**
The test validates end-to-end quiz preprocessing including:
- Quiz macro replacement (`{{#quiz}}`)
- HTML/JavaScript injection
- Auto-ID generation for quiz questions
- File I/O from disk

All tests pass with mdbook 0.5.2:

```
$ cargo test --all
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running unittests src/main.rs (target/debug/deps/mdbook_quiz-e3b7f5acfdae7e08)
running 1 test
test test::test_quiz_generator ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
Compatibility
```

Status | Version / Note
-- | --
Supported | mdBook 0.5.x (tested with 0.5.2)
Dropped | mdBook 0.4.x — use mdbook-quiz 0.4.0 for 0.4.x

No changes to quiz files required - The quiz TOML schema remains backward compatible

## Disclaimer
I've used AI to analyze the new API from mdBook, focusing on the mdbook-quiz dependencies and repository structure. I've manually tested and compiled the floresta-docs, which I'm currently reading; I'm not a maintainer of the project. I have also coded most of the PR myself. I feel this disclaimer is necessary because I genuinely want to contribute without bothering the maintainers of the project.
